### PR TITLE
feat: enhance web search source links with inline favicon bubbles

### DIFF
--- a/frontend/web/src/components/chat-body/ChatBody.tsx
+++ b/frontend/web/src/components/chat-body/ChatBody.tsx
@@ -6,6 +6,7 @@ import { FaFileCsv } from "react-icons/fa6";
 import { useState } from 'react';
 import styles from './ChatBody.module.css';
 import Image from 'next/image';
+import SourceBubble from '../source-bubble/SourceBubble';
 
 interface Message {
   id: string;
@@ -258,14 +259,7 @@ export const ChatBody = ({ messages }: { messages: Message[] }) => {
                       strong: ({ children }) => <strong className="font-semibold text-white">{children}</strong>,
                       em: ({ children }) => <em className="italic text-white">{children}</em>,
                       a: ({ children, href }) => (
-                        <a 
-                          href={href} 
-                          className="text-blue-400 hover:text-blue-300 underline"
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          {children}
-                        </a>
+                        <SourceBubble href={href || ''} />
                       ),
                       table: ({ children }) => (
                         <div className="overflow-x-auto mb-3">

--- a/frontend/web/src/components/source-bubble/SourceBubble.module.css
+++ b/frontend/web/src/components/source-bubble/SourceBubble.module.css
@@ -1,0 +1,79 @@
+.container {
+  position: relative;
+  display: inline-block;
+  margin: 0 2px;
+}
+
+.bubble {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  background: rgba(59, 130, 246, 0.15);
+  border: 1px solid rgba(59, 130, 246, 0.3);
+  border-radius: 50%;
+  text-decoration: none;
+  transition: all 0.2s ease;
+  position: relative;
+  vertical-align: middle;
+}
+
+.bubble:hover {
+  background: rgba(59, 130, 246, 0.25);
+  border-color: rgba(59, 130, 246, 0.5);
+  transform: scale(1.1);
+}
+
+.iconContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 12px;
+  height: 12px;
+}
+
+.favicon {
+  width: 12px;
+  height: 12px;
+  border-radius: 2px;
+}
+
+.defaultIcon {
+  width: 10px;
+  height: 10px;
+  color: rgba(147, 197, 253, 0.8);
+}
+
+.tooltip {
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  transform: translateX(-50%) translateY(-4px);
+  background: rgba(17, 24, 39, 0.95);
+  color: white;
+  padding: 4px 8px;
+  border-radius: 6px;
+  font-size: 12px;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  backdrop-filter: blur(8px);
+  border: 1px solid rgba(75, 85, 99, 0.3);
+  z-index: 1000;
+}
+
+.tooltip::after {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%);
+  border: 4px solid transparent;
+  border-top-color: rgba(17, 24, 39, 0.95);
+}
+
+.tooltip.visible {
+  opacity: 1;
+}

--- a/frontend/web/src/components/source-bubble/SourceBubble.tsx
+++ b/frontend/web/src/components/source-bubble/SourceBubble.tsx
@@ -1,0 +1,65 @@
+import React, { useState } from 'react';
+import styles from './SourceBubble.module.css';
+
+interface SourceBubbleProps {
+  href: string;
+  children: React.ReactNode;
+}
+
+const SourceBubble: React.FC<SourceBubbleProps> = ({ href }) => {
+  const [isHovered, setIsHovered] = useState(false);
+  const [imageError, setImageError] = useState(false);
+
+  const getDomain = (url: string) => {
+    try {
+      return new URL(url).hostname.replace('www.', '');
+    } catch {
+      return 'link';
+    }
+  };
+
+  const getFaviconUrl = (url: string) => {
+    try {
+      const domain = new URL(url).hostname;
+      return `https://www.google.com/s2/favicons?domain=${domain}&sz=16`;
+    } catch {
+      return null;
+    }
+  };
+
+  const domain = getDomain(href);
+  const faviconUrl = getFaviconUrl(href);
+
+  return (
+    <span className={styles.container}>
+      <a
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={styles.bubble}
+        onMouseEnter={() => setIsHovered(true)}
+        onMouseLeave={() => setIsHovered(false)}
+      >
+        <span className={styles.iconContainer}>
+          {faviconUrl && !imageError ? (
+            <img
+              src={faviconUrl}
+              alt=""
+              className={styles.favicon}
+              onError={() => setImageError(true)}
+            />
+          ) : (
+            <svg className={styles.defaultIcon} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+            </svg>
+          )}
+        </span>
+        <span className={`${styles.tooltip} ${isHovered ? styles.visible : ''}`}>
+          {domain}
+        </span>
+      </a>
+    </span>
+  );
+};
+
+export default SourceBubble;


### PR DESCRIPTION
## Summary
- Replace plain blue text links with small circular favicon bubbles that appear inline within text
- Bubbles show the website's favicon and expand on hover to display the domain name
- Provides a cleaner and more intuitive way to display source links in web search results

## Test plan
- [x] Test web search functionality with source links
- [x] Verify favicon bubbles appear inline in chat messages
- [x] Check hover tooltips show correct domain names
- [x] Ensure fallback icon displays when favicon fails to load

🤖 Generated with [Claude Code](https://claude.ai/code)